### PR TITLE
Fix lint and charm proof errors

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,8 @@
 name: nginx
+maintainers: ['Adam Stokes <adam.stokes@ubuntu.com>']
+tags: ['HTTP server']
 summary: |
-  NGINX is a free, open-source, high-performance HTTP server and reverse proxy, as well as an IMAP/POP3 proxy server.
+  NGINX is an HTTP server, reverse proxy and IMAP/POP3 proxy server.
 description: |
   NGINX is a free, open-source, high-performance HTTP server and reverse proxy, as well as an IMAP/POP3 proxy server. NGINX is known for its high performance, stability, rich feature set, simple configuration, and low resource consumption.
 provides:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,4 @@
 name: nginx
-maintainers: ['Adam Stokes <adam.stokes@ubuntu.com>']
-tags: ['HTTP server']
 summary: |
   NGINX is an HTTP server, reverse proxy and IMAP/POP3 proxy server.
 description: |

--- a/reactive/nginx.py
+++ b/reactive/nginx.py
@@ -20,6 +20,7 @@ def nginx_ready():
     hookenv.status_set('active', 'NGINX is ready')
     set_state('nginx.available')
 
+
 # Example website.available reaction ------------------------------------------
 """
 This example reaction for an application layer which consumes this nginx layer.


### PR DESCRIPTION
Should also fix some of the Kubernetes bundle failures on CWR

Fixes: 
charm proof
```
W: summary should be less than 72
E: Charm must have either a maintainer or maintainers field
W: Metadata missing required field "tags"
I: No icon.svg file.
```

and make lint
```
py34 create: /home/jackal/workspace/charms/trusty/nginx/.tox/py34
ERROR: InterpreterNotFound: python3.4
py35 installed: flake8==3.2.0,mccabe==0.5.2,pkg-resources==0.0.0,py==1.4.31,pycodestyle==2.2.0,pyflakes==1.3.0,pytest==3.0.4
__________________________________________________________________________________ summary __________________________________________________________________________________
SKIPPED:  py34: InterpreterNotFound: python3.4
  py35: skipped tests
  congratulations :)
reactive/nginx.py:24:1: E305 expected 2 blank lines after class or function definition, found 1
Makefile:17: recipe for target 'lint' failed
make: *** [lint] Error 1
```
